### PR TITLE
Add support to extra restraints

### DIFF
--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -2,12 +2,14 @@ package dataset
 
 import (
 	"benchmarktools/input"
+	"benchmarktools/runner"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
-func TestWriteRunParam(t *testing.T) {
+func TestWriteRunParamStub(t *testing.T) {
 
 	_ = os.Mkdir("1abc", 0755)
 	defer os.RemoveAll("1abc")
@@ -27,7 +29,7 @@ func TestWriteRunParam(t *testing.T) {
 		LigandList:   "some/path/ligand.list",
 	}
 
-	_, err := target.WriteRunParam(projectDir, haddockDir)
+	_, err := target.WriteRunParamStub(projectDir, haddockDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -35,7 +37,7 @@ func TestWriteRunParam(t *testing.T) {
 	// Fail by writing a run parameter file with an empty target
 	target = Target{}
 
-	_, err = target.WriteRunParam(projectDir, haddockDir)
+	_, err = target.WriteRunParamStub(projectDir, haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -47,7 +49,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{"1abc.pdb"},
 	}
 
-	_, err = target.WriteRunParam(projectDir, haddockDir)
+	_, err = target.WriteRunParamStub(projectDir, haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -59,7 +61,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{},
 	}
 
-	_, err = target.WriteRunParam(projectDir, haddockDir)
+	_, err = target.WriteRunParamStub(projectDir, haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -71,7 +73,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{"1abc.pdb"},
 	}
 
-	_, err = target.WriteRunParam(projectDir, "")
+	_, err = target.WriteRunParamStub(projectDir, "")
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -83,7 +85,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{"1abc.pdb"},
 	}
 
-	_, err = target.WriteRunParam("", haddockDir)
+	_, err = target.WriteRunParamStub("", haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -95,7 +97,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{"1abc.pdb"},
 	}
 
-	_, err = target.WriteRunParam("", haddockDir)
+	_, err = target.WriteRunParamStub("", haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -107,7 +109,7 @@ func TestWriteRunParam(t *testing.T) {
 		Ligand:   []string{"1abc.pdb"},
 	}
 
-	_, err = target.WriteRunParam("some/path/that/does/not/exist", haddockDir)
+	_, err = target.WriteRunParamStub("some/path/that/does/not/exist", haddockDir)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -497,40 +499,6 @@ func TestOrganizeDataset(t *testing.T) {
 
 }
 
-func TestSetupHaddock24Scenario(t *testing.T) {
-
-	s := input.Scenario{
-		Name: "scenario1",
-	}
-	target := Target{
-		ID:         "1abc",
-		Receptor:   []string{"receptor.pdb"},
-		Ligand:     []string{"ligand.pdb"},
-		Restraints: []string{"ambig.tbl", "unambig.tbl"},
-		Toppar:     []string{"custom.top", "custom.param"},
-	}
-	wd := "some-workdir"
-	hdir := "haddock-dir"
-	defer os.RemoveAll(wd)
-
-	j, err := target.SetupHaddock24Scenario(wd, hdir, s)
-	if err != nil {
-		t.Errorf("Failed to setup scenario: %s", err)
-	}
-
-	if j.ID != target.ID+"_"+s.Name {
-		t.Errorf("Wrong scenario name: %s", j.ID)
-	}
-
-	// Fail by trying to setup a scenario without defining the HaddockDir field
-	hdir = ""
-	_, err = target.SetupHaddock24Scenario(wd, hdir, s)
-	if err == nil {
-		t.Errorf("Failed to detect wrong input")
-	}
-
-}
-
 func TestSetupHaddock3Scenario(t *testing.T) {
 
 	inp := input.Input{}
@@ -656,4 +624,104 @@ func TestWriteRunToml(t *testing.T) {
 		t.Errorf("Failed to detect wrong input")
 	}
 
+}
+
+func TestTarget_SetupHaddock24Scenario(t *testing.T) {
+	type fields struct {
+		ID           string
+		Receptor     []string
+		ReceptorList string
+		Ligand       []string
+		LigandList   string
+		Restraints   []string
+		Toppar       []string
+		MiscPDB      []string
+	}
+	type args struct {
+		wd   string
+		hdir string
+		s    input.Scenario
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    runner.Job
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "pass",
+			fields: fields{
+				ID:         "1abc",
+				Receptor:   []string{"receptor.pdb"},
+				Ligand:     []string{"ligand.pdb"},
+				Restraints: []string{"ambig_ti.tbl", "other_unambig.tbl", "something.tbl"},
+				Toppar:     []string{"custom1.top", "custom2.param"},
+			},
+			args: args{
+				wd:   "some-workdir",
+				hdir: "haddock-dir",
+				s: input.Scenario{
+					Name: "some-scenario",
+					Parameters: input.ScenarioParams{
+						Restraints: input.Restraints{
+							Ambig:   "_ti",
+							Unambig: "_unambig",
+						},
+					},
+				},
+			},
+			want: runner.Job{
+				ID:   "1abc_some-scenario",
+				Path: "some-workdir/1abc/scenario-some-scenario",
+				Restraints: input.Restraints{
+					Ambig:   "ambig_ti.tbl",
+					Unambig: "other_unambig.tbl",
+				},
+				Toppar: input.Toppar{
+					Topology: "custom1.top",
+					Param:    "custom2.param",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail",
+			fields: fields{
+				ID: "1abc",
+			},
+			args: args{
+				wd:   "some-workdir",
+				hdir: "",
+				s: input.Scenario{
+					Name: "some-scenario",
+				},
+			},
+			want:    runner.Job{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Target{
+				ID:           tt.fields.ID,
+				Receptor:     tt.fields.Receptor,
+				ReceptorList: tt.fields.ReceptorList,
+				Ligand:       tt.fields.Ligand,
+				LigandList:   tt.fields.LigandList,
+				Restraints:   tt.fields.Restraints,
+				Toppar:       tt.fields.Toppar,
+				MiscPDB:      tt.fields.MiscPDB,
+			}
+			got, err := tr.SetupHaddock24Scenario(tt.args.wd, tt.args.hdir, tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Target.SetupHaddock24Scenario() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Target.SetupHaddock24Scenario() =\ngot   %v,\n want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -702,6 +702,9 @@ func TestTarget_SetupHaddock24Scenario(t *testing.T) {
 			wantErr: true,
 		},
 	}
+
+	defer os.RemoveAll("some-workdir")
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &Target{

--- a/example/example_haddock24.yml
+++ b/example/example_haddock24.yml
@@ -9,8 +9,6 @@ general:
   work_dir: /Users/rvhonorato/repos/benchmark-tools/bm-goes-here
 
 scenarios:
-  #-----------------------------------------------
-  # Haddock2.4
   - name: true-interface
     parameters:
       run_cns:
@@ -41,6 +39,5 @@ scenarios:
         structures_0: 2
         structures_1: 2
         waterrefine: 2
-  #-----------------------------------------------
 
   #-----------------------------------------------

--- a/input/input.go
+++ b/input/input.go
@@ -53,8 +53,37 @@ type ScenarioParams struct {
 
 // Restraints is the restraints structure
 type Restraints struct {
-	Ambig   string
-	Unambig string
+	Ambig     string
+	Unambig   string
+	Dihedrals string
+	Hbonds    string
+	Tensor    string
+	Cryoem    string
+	Rdc1      string
+	Rdc2      string
+	Rdc3      string
+	Rdc4      string
+	Rdc5      string
+	Rdc6      string
+	Rdc7      string
+	Rdc8      string
+	Rdc9      string
+	Rdc10     string
+	Dani1     string
+	Dani2     string
+	Dani3     string
+	Dani4     string
+	Dani5     string
+	Pcs1      string
+	Pcs2      string
+	Pcs3      string
+	Pcs4      string
+	Pcs5      string
+	Pcs6      string
+	Pcs7      string
+	Pcs8      string
+	Pcs9      string
+	Pcs10     string
 }
 
 // Toppar is the toppar structure

--- a/main.go
+++ b/main.go
@@ -189,8 +189,7 @@ func main() {
 
 			if haddockVersion == 2 {
 
-				_, errSetup2 := job.SetupHaddock24(inp.General.HaddockExecutable)
-
+				errSetup2 := job.SetupHaddock24(inp.General.HaddockExecutable)
 				if errSetup2 != nil {
 					glog.Error("Failed to setup HADDOCK: " + errSetup2.Error())
 					return

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -34,7 +34,6 @@ func (j Job) SetupHaddock24(cmd string) error {
 		j.Restraints.Unambig:   "UNAMBIG_TBL",
 		j.Restraints.Hbonds:    "HBOND_FILE",
 		j.Restraints.Dihedrals: "DIHED_FILE",
-		j.Restraints.Hbonds:    "HBOND_FILE",
 		j.Restraints.Tensor:    "TENSOR_FILE",
 		j.Restraints.Cryoem:    "CRYO-EM_FILE",
 		j.Restraints.Rdc1:      "RDC1_FILE",


### PR DESCRIPTION
This PR adds support to the restraints used by HADDOCK2.4, it does so by writing them to the `run.param`