### PR TITLE
fix incomplete support for relative paths

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -155,23 +155,23 @@ func (t *Target) WriteRunParamStub(projectDir string, haddockDir string) (string
 
 	runParamString += "N_COMP=2\n"
 	runParamString += "RUN_NUMBER=1\n"
-	runParamString += "PROJECT_DIR=" + projectDir + "\n"
+	runParamString += "PROJECT_DIR=./\n"
 	runParamString += "HADDOCK_DIR=" + haddockDir + "\n"
 
 	// Write receptor files
-	runParamString += "PDB_FILE1=" + t.Receptor[0] + "\n"
+	runParamString += "PDB_FILE1=../data/" + filepath.Base(t.Receptor[0]) + "\n"
 
 	// Write receptor list file
 	if t.ReceptorList != "" {
-		runParamString += "PDB_LIST1=" + t.ReceptorList + "\n"
+		runParamString += "PDB_LIST1=../data" + filepath.Base(t.ReceptorList) + "\n"
 	}
 
 	// Write ligand files
-	runParamString += "PDB_FILE2=" + t.Ligand[0] + "\n"
+	runParamString += "PDB_FILE2=../data/" + filepath.Base(t.Ligand[0]) + "\n"
 
 	// write ligand list files
 	if t.LigandList != "" {
-		runParamString += "PDB_LIST2=" + t.LigandList + "\n"
+		runParamString += "PDB_LIST2=../data" + filepath.Base(t.LigandList) + "\n"
 	}
 
 	runParamF := filepath.Join(projectDir, "/run.param")
@@ -238,10 +238,10 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 	runTomlString += "run_dir = \"run1\"\n"
 	runTomlString += "molecules = [\n"
 	for _, r := range t.Receptor {
-		runTomlString += "    \"" + r + "\",\n"
+		runTomlString += "    \"../data/" + filepath.Base(r) + "\",\n"
 	}
 	for _, l := range t.Ligand {
-		runTomlString += "    \"" + l + "\",\n"
+		runTomlString += "    \"../data/" + filepath.Base(l) + "\",\n"
 	}
 	runTomlString += "]\n\n"
 
@@ -261,19 +261,19 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 						// Find the restraint that matches the pattern
 						for _, r := range t.Restraints {
 							if strings.Contains(r, v.(string)) {
-								runTomlString += k + " = \"" + r + "\"\n"
+								runTomlString += k + " = \"../data/" + filepath.Base(r) + "\"\n"
 							}
 						}
 						// Find the toppar that matches the pattern
 						for _, r := range t.Toppar {
 							if strings.Contains(r, v.(string)) {
-								runTomlString += k + " = \"" + r + "\"\n"
+								runTomlString += k + " = \"../data/" + filepath.Base(r) + "\"\n"
 							}
 						}
 						// Find a PDB that matches the pattern
 						for _, r := range t.MiscPDB {
 							if strings.Contains(r, v.(string)) {
-								runTomlString += k + " = \"" + r + "\"\n"
+								runTomlString += k + " = \"../data/" + filepath.Base(r) + "\"\n"
 							}
 						}
 

--- a/input/input.go
+++ b/input/input.go
@@ -123,6 +123,11 @@ func (inp *Input) ValidateExecutable() error {
 		return err
 	}
 
+	if !filepath.IsAbs(inp.General.HaddockExecutable) {
+		err := errors.New("`" + inp.General.HaddockExecutable + "` is not an absolute path")
+		return err
+	}
+
 	info, err := os.Stat(inp.General.HaddockExecutable)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const version = "v1.2.0"
+const version = "v1.3.1"
 
 func init() {
 	var versionPrint bool

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -71,7 +71,7 @@ func (j Job) SetupHaddock24(cmd string) error {
 
 	for k, v := range m {
 		if k != "" {
-			_, _ = f.WriteString(v + "=" + k + "\n")
+			_, _ = f.WriteString(v + "=../data/" + filepath.Base(k) + "\n")
 		}
 	}
 
@@ -91,14 +91,16 @@ func (j Job) SetupHaddock24(cmd string) error {
 	topparPath := filepath.Join(j.Path, "run1", "toppar")
 	if j.Toppar.Topology != "" {
 		dest := filepath.Join(topparPath, "ligand.top")
-		if err := utils.CopyFile(j.Toppar.Topology, dest); err != nil {
+		src := j.Toppar.Topology
+		if err := utils.CopyFile(src, dest); err != nil {
 			err := errors.New("Error copying custom topology: " + err.Error())
 			return err
 		}
 	}
 	if j.Toppar.Param != "" {
 		dest := filepath.Join(topparPath, "ligand.param")
-		if err := utils.CopyFile(j.Toppar.Param, dest); err != nil {
+		src := j.Toppar.Param
+		if err := utils.CopyFile(src, dest); err != nil {
 			err := errors.New("Error copying custom param: " + err.Error())
 			return err
 		}


### PR DESCRIPTION
This PR adds support to relative paths in `work_dir` and refactors the logic of writing `run.param|toml` to use relative paths.

Before they'd be written as:

`run.param`
```bash
# before
PDB_FILE1=WORK_DIR/ROOT_NAME/data/filename.pdb

# now
PDB_FILE1=../data/filename.pdb
```

`run.toml`
```toml
# before
molecules = [
    "WORK_DIR/ROOT_NAME/data/filename.pdb"
]

# now
molecules = [
    "../data/filename.pdb"
]
```

This should also avoid us going over the maximum number of characters in a string supported by CNS

For simplicity sake of the code, the `executable` now MUST be a absolute path, this might be problematic when running in clusters with stripe/scratch partitions and such, but let's fix that when we encounter it.
