### PR TITLE
add support for runs without ligand

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -148,11 +148,6 @@ func (t *Target) WriteRunParamStub(projectDir string, haddockDir string) (string
 		return "", err
 	}
 
-	if len(t.Ligand) == 0 {
-		err := errors.New("ligand not defined")
-		return "", err
-	}
-
 	runParamString += "N_COMP=2\n"
 	runParamString += "RUN_NUMBER=1\n"
 	runParamString += "PROJECT_DIR=./\n"
@@ -167,11 +162,13 @@ func (t *Target) WriteRunParamStub(projectDir string, haddockDir string) (string
 	}
 
 	// Write ligand files
-	runParamString += "PDB_FILE2=../data/" + filepath.Base(t.Ligand[0]) + "\n"
+	if len(t.Ligand) > 1 {
+		runParamString += "PDB_FILE2=../data/" + filepath.Base(t.Ligand[0]) + "\n"
 
-	// write ligand list files
-	if t.LigandList != "" {
-		runParamString += "PDB_LIST2=../data" + filepath.Base(t.LigandList) + "\n"
+		// write ligand list files
+		if t.LigandList != "" {
+			runParamString += "PDB_LIST2=../data" + filepath.Base(t.LigandList) + "\n"
+		}
 	}
 
 	runParamF := filepath.Join(projectDir, "/run.param")

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -308,7 +308,13 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 // LoadDataset loads a dataset from a list file
 func LoadDataset(projectDir string, pdbList string, rsuf string, lsuf string) ([]Target, error) {
 
-	rootRegex := regexp.MustCompile(`(.*)(?:` + rsuf + `|` + lsuf + `)`)
+	var rootRegex *regexp.Regexp
+	if lsuf == "" {
+		rootRegex = regexp.MustCompile(`(.*)(?:` + rsuf + `)`)
+	} else {
+		rootRegex = regexp.MustCompile(`(.*)(?:` + rsuf + `|` + lsuf + `)`)
+	}
+
 	recRegex := regexp.MustCompile(`(.*)` + rsuf)
 	ligRegex := regexp.MustCompile(`(.*)` + lsuf)
 	_ = os.MkdirAll(projectDir, 0755)
@@ -383,8 +389,9 @@ func LoadDataset(projectDir string, pdbList string, rsuf string, lsuf string) ([
 	// Check if Targets have both receptor and ligand
 	for _, v := range m {
 		if len(v.Receptor) == 0 || len(v.Ligand) == 0 {
-			err := errors.New("Target " + v.ID + " does not have both receptor and ligand")
-			return nil, err
+			glog.Warning("Target " + v.ID + " does not have both receptor and ligand")
+			// err := errors.New("Target " + v.ID + " does not have both receptor and ligand")
+			// return nil, err
 		}
 	}
 

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -54,7 +54,7 @@ func TestWriteRunParamStub(t *testing.T) {
 		t.Error("Expected error, got nil")
 	}
 
-	// Fail by writing a run parameter file with an empty ligand
+	// Pass by writing a run parameter file with an empty ligand
 	target = Target{
 		ID:       "1abc",
 		Receptor: []string{"1abcA.pdb", "1abcB.pdb"},
@@ -62,7 +62,7 @@ func TestWriteRunParamStub(t *testing.T) {
 	}
 
 	_, err = target.WriteRunParamStub(projectDir, haddockDir)
-	if err == nil {
+	if err != nil {
 		t.Error("Expected error, got nil")
 	}
 
@@ -201,8 +201,8 @@ func TestLoadDataset(t *testing.T) {
 	}
 
 	defer os.Remove("pdb2.list")
-	_, errData = LoadDataset(projectDir, "pdb2.list", "_r_u", "_l_u")
-	if errData == nil {
+	_, errData = LoadDataset(projectDir, "pdb2.list", "_r_u", "")
+	if errData != nil {
 		t.Errorf("Failed to detect wrong dataset file")
 	}
 

--- a/input/input.go
+++ b/input/input.go
@@ -144,8 +144,8 @@ func (inp *Input) ValidateExecutable() error {
 func (inp *Input) ValidatePatterns() error {
 
 	// ReceptorSuffix and LigandSuffix
-	if inp.General.ReceptorSuffix == "" || inp.General.LigandSuffix == "" {
-		err := errors.New("receptor_suffix or ligand_suffix not defined in `general` section")
+	if inp.General.ReceptorSuffix == "" {
+		err := errors.New("receptor_suffix not defined in `general` section")
 		return err
 	} else if inp.General.ReceptorSuffix == inp.General.LigandSuffix {
 		err := errors.New("receptor_suffix and ligand_suffix are the same at `general` section")

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const version = "v1.3.3"
+const version = "v1.4.0"
 
 func init() {
 	var versionPrint bool


### PR DESCRIPTION
HADDOCK supports runs with just the receptor defined; so now the ligand_suffix is an optional parameter