### PR TITLE
Allow for expandable parameters

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,10 +29,3 @@ jobs:
 
       - name: Run codacy-coverage-reporter
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --force-coverage-parser go -r coverage.out
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.out

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -229,7 +229,14 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 			runTomlString += k + " = " + strconv.FormatFloat(v, 'f', -1, 64) + "\n"
 		case bool:
 			runTomlString += k + " = " + strconv.FormatBool(v) + "\n"
+		case []string:
+			runTomlString += k + " = [" + strings.Join(v, ",") + "]\n"
+		case []int:
+			runTomlString += k + " = [" + strings.Join(utils.IntSliceToStringSlice(v), ",") + "]\n"
+		case []float64:
+			runTomlString += k + " = [" + strings.Join(utils.FloatSliceToStringSlice(v), ",") + "]\n"
 		}
+
 	}
 
 	runTomlString += "run_dir = \"run1\"\n"
@@ -284,6 +291,12 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 							runTomlString += k + " = " + strconv.FormatFloat(v, 'f', -1, 64) + "\n"
 						case bool:
 							runTomlString += k + " = " + strconv.FormatBool(v) + "\n"
+						case []string:
+							runTomlString += k + " = [" + strings.Join(v, ",") + "]\n"
+						case []int:
+							runTomlString += k + " = [" + strings.Join(utils.IntSliceToStringSlice(v), ",") + "]\n"
+						case []float64:
+							runTomlString += k + " = [" + strings.Join(utils.FloatSliceToStringSlice(v), ",") + "]\n"
 						}
 					}
 				}

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -297,6 +297,8 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 							runTomlString += k + " = [" + strings.Join(utils.IntSliceToStringSlice(v), ",") + "]\n"
 						case []float64:
 							runTomlString += k + " = [" + strings.Join(utils.FloatSliceToStringSlice(v), ",") + "]\n"
+						case []interface{}:
+							runTomlString += k + " = [" + strings.Join(utils.InterfaceSliceToStringSlice(v), ",") + "]\n"
 						}
 					}
 				}

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -737,6 +737,8 @@ func TestTarget_WriteRunToml(t *testing.T) {
 						"array-float":      []float64{1.1, 2.2, 3.3},
 						"array-string":     []string{"a", "b", "c"},
 						"array-bool":       []bool{true, false, true},
+						"array-interface":  []interface{}{1, 2.2, "three", true},
+						"expandable_":      []int{1, 2, 3},
 					},
 					Mdref: map[string]interface{}{
 						"some-other-param": false,

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -564,68 +564,6 @@ func TestSetupHaddock3Scenario(t *testing.T) {
 
 }
 
-// func TestWriteRunToml(t *testing.T) {
-
-// 	// Create a temporary directory
-// 	_ = os.MkdirAll("_some-workdir", 0755)
-// 	defer os.RemoveAll("_some-workdir")
-
-// 	target := Target{
-// 		ID:         "1abc",
-// 		Receptor:   []string{"receptor.pdb"},
-// 		Ligand:     []string{"ligand.pdb"},
-// 		Restraints: []string{"ambig.tbl", "unambig.tbl", "something.tbl"},
-// 		Toppar:     []string{"custom1.top", "custom2.param"},
-// 		MiscPDB:    []string{"ref.pdb"},
-// 	}
-
-// 	m := input.ModuleParams{
-// 		Order: []string{"topoaa", "rigidbody", "flexref", "mdref"},
-// 		Topoaa: map[string]interface{}{
-// 			"some-param": "some-value",
-// 		},
-// 		Rigidbody: map[string]interface{}{
-// 			"some-other-param":   10,
-// 			"some_fname":         "ambig",
-// 			"another_fname":      "unambig",
-// 			"other_fname":        "custom1",
-// 			"someother_fname":    "custom2",
-// 			"thereference_fname": "ref",
-// 		},
-// 		Flexref: map[string]interface{}{
-// 			"some-other-param": 3.5,
-// 		},
-// 		Mdref: map[string]interface{}{
-// 			"some-other-param": false,
-// 		},
-// 	}
-
-// 	g := make(map[string]interface{})
-// 	g["general-param1"] = "general-value"
-// 	g["general-param2"] = 2.5
-// 	g["general-param3"] = false
-// 	g["general-param4"] = 1
-
-// 	_, err := target.WriteRunToml("_some-workdir", g, m)
-
-// 	if err != nil {
-// 		t.Errorf("Failed to write run.toml: %s", err)
-// 	}
-
-// 	// check if the run.toml was written to disk
-// 	runTomlPath := filepath.Join("_some-workdir", "run.toml")
-// 	if _, err := os.Stat(runTomlPath); os.IsNotExist(err) {
-// 		t.Errorf("run.toml was not written to disk")
-// 	}
-
-// 	// Fail by trying to write to a directory that does not exist
-// 	_, err = target.WriteRunToml("_some-workdir/does_not_exist", g, m)
-// 	if err == nil {
-// 		t.Errorf("Failed to detect wrong input")
-// 	}
-
-// }
-
 func TestTarget_SetupHaddock24Scenario(t *testing.T) {
 	type fields struct {
 		ID           string

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -564,67 +564,67 @@ func TestSetupHaddock3Scenario(t *testing.T) {
 
 }
 
-func TestWriteRunToml(t *testing.T) {
+// func TestWriteRunToml(t *testing.T) {
 
-	// Create a temporary directory
-	_ = os.MkdirAll("_some-workdir", 0755)
-	defer os.RemoveAll("_some-workdir")
+// 	// Create a temporary directory
+// 	_ = os.MkdirAll("_some-workdir", 0755)
+// 	defer os.RemoveAll("_some-workdir")
 
-	target := Target{
-		ID:         "1abc",
-		Receptor:   []string{"receptor.pdb"},
-		Ligand:     []string{"ligand.pdb"},
-		Restraints: []string{"ambig.tbl", "unambig.tbl", "something.tbl"},
-		Toppar:     []string{"custom1.top", "custom2.param"},
-		MiscPDB:    []string{"ref.pdb"},
-	}
+// 	target := Target{
+// 		ID:         "1abc",
+// 		Receptor:   []string{"receptor.pdb"},
+// 		Ligand:     []string{"ligand.pdb"},
+// 		Restraints: []string{"ambig.tbl", "unambig.tbl", "something.tbl"},
+// 		Toppar:     []string{"custom1.top", "custom2.param"},
+// 		MiscPDB:    []string{"ref.pdb"},
+// 	}
 
-	m := input.ModuleParams{
-		Order: []string{"topoaa", "rigidbody", "flexref", "mdref"},
-		Topoaa: map[string]interface{}{
-			"some-param": "some-value",
-		},
-		Rigidbody: map[string]interface{}{
-			"some-other-param":   10,
-			"some_fname":         "ambig",
-			"another_fname":      "unambig",
-			"other_fname":        "custom1",
-			"someother_fname":    "custom2",
-			"thereference_fname": "ref",
-		},
-		Flexref: map[string]interface{}{
-			"some-other-param": 3.5,
-		},
-		Mdref: map[string]interface{}{
-			"some-other-param": false,
-		},
-	}
+// 	m := input.ModuleParams{
+// 		Order: []string{"topoaa", "rigidbody", "flexref", "mdref"},
+// 		Topoaa: map[string]interface{}{
+// 			"some-param": "some-value",
+// 		},
+// 		Rigidbody: map[string]interface{}{
+// 			"some-other-param":   10,
+// 			"some_fname":         "ambig",
+// 			"another_fname":      "unambig",
+// 			"other_fname":        "custom1",
+// 			"someother_fname":    "custom2",
+// 			"thereference_fname": "ref",
+// 		},
+// 		Flexref: map[string]interface{}{
+// 			"some-other-param": 3.5,
+// 		},
+// 		Mdref: map[string]interface{}{
+// 			"some-other-param": false,
+// 		},
+// 	}
 
-	g := make(map[string]interface{})
-	g["general-param1"] = "general-value"
-	g["general-param2"] = 2.5
-	g["general-param3"] = false
-	g["general-param4"] = 1
+// 	g := make(map[string]interface{})
+// 	g["general-param1"] = "general-value"
+// 	g["general-param2"] = 2.5
+// 	g["general-param3"] = false
+// 	g["general-param4"] = 1
 
-	_, err := target.WriteRunToml("_some-workdir", g, m)
+// 	_, err := target.WriteRunToml("_some-workdir", g, m)
 
-	if err != nil {
-		t.Errorf("Failed to write run.toml: %s", err)
-	}
+// 	if err != nil {
+// 		t.Errorf("Failed to write run.toml: %s", err)
+// 	}
 
-	// check if the run.toml was written to disk
-	runTomlPath := filepath.Join("_some-workdir", "run.toml")
-	if _, err := os.Stat(runTomlPath); os.IsNotExist(err) {
-		t.Errorf("run.toml was not written to disk")
-	}
+// 	// check if the run.toml was written to disk
+// 	runTomlPath := filepath.Join("_some-workdir", "run.toml")
+// 	if _, err := os.Stat(runTomlPath); os.IsNotExist(err) {
+// 		t.Errorf("run.toml was not written to disk")
+// 	}
 
-	// Fail by trying to write to a directory that does not exist
-	_, err = target.WriteRunToml("_some-workdir/does_not_exist", g, m)
-	if err == nil {
-		t.Errorf("Failed to detect wrong input")
-	}
+// 	// Fail by trying to write to a directory that does not exist
+// 	_, err = target.WriteRunToml("_some-workdir/does_not_exist", g, m)
+// 	if err == nil {
+// 		t.Errorf("Failed to detect wrong input")
+// 	}
 
-}
+// }
 
 func TestTarget_SetupHaddock24Scenario(t *testing.T) {
 	type fields struct {
@@ -724,6 +724,128 @@ func TestTarget_SetupHaddock24Scenario(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Target.SetupHaddock24Scenario() =\ngot   %v,\n want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTarget_WriteRunToml(t *testing.T) {
+	// make a directory to be used as the workdir
+	err := os.MkdirAll("_some-workdir", 0755)
+	if err != nil {
+		t.Errorf("Failed to create workdir: %s", err)
+	}
+	defer os.RemoveAll("_some-workdir")
+	type fields struct {
+		ID           string
+		Receptor     []string
+		ReceptorList string
+		Ligand       []string
+		LigandList   string
+		Restraints   []string
+		Toppar       []string
+		MiscPDB      []string
+	}
+	type args struct {
+		projectDir string
+		general    map[string]interface{}
+		mod        input.ModuleParams
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "pass",
+			fields: fields{
+				ID:         "1abc",
+				Receptor:   []string{"receptor.pdb"},
+				Ligand:     []string{"ligand.pdb"},
+				Restraints: []string{"ambig_ti.tbl", "other_unambig.tbl", "something.tbl"},
+				Toppar:     []string{"custom1.top", "custom2.param"},
+				MiscPDB:    []string{"ref.pdb"},
+			},
+			args: args{
+				projectDir: "_some-workdir",
+				general: map[string]interface{}{
+					"receptor":     "receptor.pdb",
+					"ligand":       "ligand.pdb",
+					"int":          10,
+					"float":        3.5,
+					"bool":         true,
+					"array-string": []string{"a", "b", "c"},
+					"array-int":    []int{1, 2, 3},
+					"array-float":  []float64{1.1, 2.2, 3.3},
+				},
+				mod: input.ModuleParams{
+					Order: []string{"topoaa", "rigidbody", "flexref", "mdref"},
+					Topoaa: map[string]interface{}{
+						"some-param": "some-value",
+					},
+					Rigidbody: map[string]interface{}{
+						"some-other-param":   10,
+						"some_fname":         "ambig",
+						"another_fname":      "unambig",
+						"other_fname":        "custom1",
+						"someother_fname":    "custom2",
+						"thereference_fname": "ref",
+					},
+					Flexref: map[string]interface{}{
+						"some-other-param": 3.5,
+						"array-int":        []int{1, 2, 3},
+						"array-float":      []float64{1.1, 2.2, 3.3},
+						"array-string":     []string{"a", "b", "c"},
+						"array-bool":       []bool{true, false, true},
+					},
+					Mdref: map[string]interface{}{
+						"some-other-param": false,
+					},
+				},
+			},
+			want:    "_some-workdir/run.toml",
+			wantErr: false,
+		},
+		{
+			name: "fail-by-not-being-able-to-create-file",
+			fields: fields{
+				ID:         "1abc",
+				Receptor:   []string{"receptor.pdb"},
+				Ligand:     []string{"ligand.pdb"},
+				Restraints: []string{"ambig_ti.tbl", "other_unambig.tbl", "something.tbl"},
+				Toppar:     []string{"custom1.top", "custom2.param"},
+				MiscPDB:    []string{"ref.pdb"},
+			},
+			args: args{
+				projectDir: "unexisting-directory",
+				general:    map[string]interface{}{},
+				mod:        input.ModuleParams{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Target{
+				ID:           tt.fields.ID,
+				Receptor:     tt.fields.Receptor,
+				ReceptorList: tt.fields.ReceptorList,
+				Ligand:       tt.fields.Ligand,
+				LigandList:   tt.fields.LigandList,
+				Restraints:   tt.fields.Restraints,
+				Toppar:       tt.fields.Toppar,
+				MiscPDB:      tt.fields.MiscPDB,
+			}
+			got, err := tr.WriteRunToml(tt.args.projectDir, tt.args.general, tt.args.mod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Target.WriteRunToml() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Target.WriteRunToml() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/input/input.go
+++ b/input/input.go
@@ -354,14 +354,20 @@ func ValidateHaddock3Params(known ModuleParams, loaded ModuleParams) error {
 	v := reflect.ValueOf(loaded)
 	k := reflect.ValueOf(known)
 
+	expandableRe := regexp.MustCompile(`(.)_\d?`)
+
 	types := v.Type()
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 		if field.Kind() == reflect.Map {
 			for key := range field.Interface().(map[string]interface{}) {
 				if !k.Field(i).MapIndex(reflect.ValueOf(key)).IsValid() {
-					err := errors.New("`" + key + "` not valid for " + types.Field(i).Name)
-					return err
+					// Check if the key is an expandable parameter
+					match := expandableRe.MatchString(key)
+					if !match {
+						err := errors.New("`" + key + "` not valid for " + types.Field(i).Name)
+						return err
+					}
 				}
 			}
 		}

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -380,42 +380,6 @@ func TestLoadHaddock3DefaultParams(t *testing.T) {
 
 }
 
-func TestValidateHaddock3Params(t *testing.T) {
-
-	known := ModuleParams{}
-	known.Rigidbody = map[string]any{
-		"param1": "value1",
-	}
-	known.Topoaa = map[string]any{
-		"param2": "value2",
-	}
-
-	test := ModuleParams{}
-	test.Rigidbody = map[string]any{
-		"param1": "value1",
-	}
-	test.Topoaa = map[string]any{
-		"param2": "value2",
-	}
-
-	// Pass by finding the parameters
-	err := ValidateHaddock3Params(known, test)
-	if err != nil {
-		t.Errorf("Failed to validate parameters: %s", err)
-	}
-
-	// Fail by not finding a parameter
-	test.Rigidbody = map[string]any{
-		"param10": "value",
-	}
-
-	err = ValidateHaddock3Params(known, test)
-	if err == nil {
-		t.Errorf("Failed to detect wrong parameters")
-	}
-
-}
-
 func TestInput_ValidateExecutable(t *testing.T) {
 	// Create a dummy executable
 	wd, _ := os.Getwd()
@@ -499,6 +463,67 @@ func TestInput_ValidateExecutable(t *testing.T) {
 			}
 			if err := inp.ValidateExecutable(); (err != nil) != tt.wantErr {
 				t.Errorf("Input.ValidateExecutable() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateHaddock3Params(t *testing.T) {
+	type args struct {
+		known  ModuleParams
+		loaded ModuleParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "pass",
+			args: args{
+				known: ModuleParams{
+					Rigidbody: map[string]any{
+						"param1": "value1",
+					},
+					Topoaa: map[string]any{
+						"param2": "value2",
+					},
+				},
+				loaded: ModuleParams{
+					Rigidbody: map[string]any{
+						"param1": "value1",
+					},
+					Topoaa: map[string]any{
+						"param2": "value2",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail",
+			args: args{
+				known: ModuleParams{
+					Rigidbody: map[string]any{
+						"param1": "value1",
+					},
+					Topoaa: map[string]any{
+						"param2": "value2",
+					},
+				},
+				loaded: ModuleParams{
+					Rigidbody: map[string]any{
+						"param10": "value",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateHaddock3Params(tt.args.known, tt.args.loaded); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHaddock3Params() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -519,6 +519,28 @@ func TestValidateHaddock3Params(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "pass-expandable-param",
+			args: args{
+				known: ModuleParams{
+					Rigidbody: map[string]any{
+						"param1_1": "value1",
+					},
+					Topoaa: map[string]any{
+						"param2_": "value2",
+					},
+				},
+				loaded: ModuleParams{
+					Rigidbody: map[string]any{
+						"param1_50": "value1",
+					},
+					Topoaa: map[string]any{
+						"param2_1": "value2",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const version = "v1.4.0"
+const version = "v1.5.0"
 
 func init() {
 	var versionPrint bool

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -168,7 +168,19 @@ func IntSliceToStringSlice(intSlice []int) []string {
 func InterfaceSliceToStringSlice(slice []interface{}) []string {
 	s := make([]string, len(slice))
 	for i, v := range slice {
-		s[i] = v.(string)
+		// this can be multiple things, so we need to convert it to a string
+		switch v := v.(type) {
+		case string:
+			s[i] = v
+		case int:
+			s[i] = strconv.Itoa(v)
+		case float64:
+			s[i] = strconv.FormatFloat(v, 'f', -1, 64)
+		case bool:
+			s[i] = strconv.FormatBool(v)
+		case nil:
+			s[i] = ""
+		}
 	}
 	return s
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -152,4 +153,31 @@ func CopyFileArrTo(files []string, dst string) error {
 	}
 
 	return nil
+}
+
+// IntSliceToStringSlice converts an int slice to a string slice
+func IntSliceToStringSlice(intSlice []int) []string {
+	var stringSlice []string
+	for _, v := range intSlice {
+		stringSlice = append(stringSlice, strconv.Itoa(v))
+	}
+	return stringSlice
+}
+
+// InterfaceSliceToStringSlice converts an interface slice to a string slice
+func InterfaceSliceToStringSlice(slice []interface{}) []string {
+	s := make([]string, len(slice))
+	for i, v := range slice {
+		s[i] = v.(string)
+	}
+	return s
+}
+
+// FloatSliceToStringSlice converts a float slice to a string slice
+func FloatSliceToStringSlice(slice []float64) []string {
+	s := make([]string, len(slice))
+	for i, v := range slice {
+		s[i] = strconv.FormatFloat(v, 'f', -1, 64)
+	}
+	return s
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"flag"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -209,4 +210,89 @@ func TestCopyFileArrTo(t *testing.T) {
 		t.Errorf("Failed to detect wrong folder")
 	}
 
+}
+
+func TestIntSliceToStringSlice(t *testing.T) {
+	type args struct {
+		intSlice []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "TestIntSliceToStringSlice",
+			args: args{
+				intSlice: []int{1, 2, 3},
+			},
+			want: []string{"1", "2", "3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IntSliceToStringSlice(tt.args.intSlice); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IntSliceToStringSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInterfaceSliceToStringSlice(t *testing.T) {
+	type args struct {
+		slice []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "TestInterfaceSliceToStringSlice",
+			args: args{
+				slice: []interface{}{"1", "2", "3"},
+			},
+			want: []string{"1", "2", "3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InterfaceSliceToStringSlice(tt.args.slice); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("InterfaceSliceToStringSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFloatSliceToStringSlice(t *testing.T) {
+	type args struct {
+		slice []float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "TestFloatSliceToStringSlice",
+			args: args{
+				slice: []float64{1.0, 2.0, 3.0},
+			},
+			want: []string{"1", "2", "3"},
+		},
+		{
+			name: "TestFloatSliceToStringSlice",
+			args: args{
+				slice: []float64{1.6, 2.1, 3.3},
+			},
+			want: []string{"1.6", "2.1", "3.3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FloatSliceToStringSlice(tt.args.slice); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FloatSliceToStringSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -254,6 +254,13 @@ func TestInterfaceSliceToStringSlice(t *testing.T) {
 			},
 			want: []string{"1", "2", "3"},
 		},
+		{
+			name: "TestInterfaceSliceToStringSlice-mutliple-types",
+			args: args{
+				slice: []interface{}{"1", 2, 3.5, true, nil},
+			},
+			want: []string{"1", "2", "3.5", "true", ""},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When setting up the scenarios we check for parameter names that do not match those specified in haddock3's `default.yaml`s file. We do it so its easier to catch the wrong parameter and fix it before running the scenarios.

This PR accomodates for such "expandable parameters" in which their actual key do not match the one in the `default.yml`; for example in `rmsdmatrix` the parameter is defined as `resdic_` in the `defaults.yaml` but it can actually be `resdic_A`, `resdic_B`, etc

While doing this I also noticed that some of these parameters are arrays, which was also not supported here, so this was also added.

Extra: I refactored some of the tests of the changed functions as table-driven tests